### PR TITLE
Working demo

### DIFF
--- a/lib/metrics.ex
+++ b/lib/metrics.ex
@@ -11,6 +11,7 @@ defmodule Metrics do
   @type view_type :: :gauge
   @type value :: {atom, number}
   @type reporter :: module
+  @type timestamp :: NaiveDateTime.t()
 
   @doc """
   Records a single measurement of a metric
@@ -31,8 +32,8 @@ defmodule Metrics do
   @doc """
   Adds a new reporter susbcribed to all the metrics
   """
-  @spec add_reporter(reporter) :: Supervisor.on_start_child()
-  def add_reporter(reporter) do
-    Reporter.start(reporter)
+  @spec add_reporter(reporter, arg :: term(), GenServer.options()) :: Supervisor.on_start_child()
+  def add_reporter(reporter, arg, opts \\ []) do
+    Reporter.start(reporter, arg, opts)
   end
 end

--- a/lib/metrics.ex
+++ b/lib/metrics.ex
@@ -3,19 +3,26 @@ defmodule Metrics do
   Application for gathering, aggregating and reporting metrics.
   """
 
-  alias Metrics.ViewStore
+  alias Metrics.{ViewStore, Gauge}
 
   @type metric :: [atom | String.t() | number]
   @type measurement :: number
   @type view :: [atom | String.t() | number]
+  @type view_type :: :gauge
 
   @doc """
   Records a single measurement of a metric
-
-  Raises an error if given metric doesn't exist.
   """
   @spec record(metric, measurement) :: :ok
   def record(metric, measurement) when is_list(metric) and is_number(measurement) do
     ViewStore.dispatch(metric, measurement)
+  end
+
+  @doc """
+  Adds a new view of the given metric
+  """
+  @spec add_view(metric, view, view_type) :: :ok | {:error, :already_exists}
+  def add_view(metric, view, :gauge) do
+    Gauge.register(metric, view)
   end
 end

--- a/lib/metrics.ex
+++ b/lib/metrics.ex
@@ -9,6 +9,8 @@ defmodule Metrics do
   @type measurement :: number
   @type view :: [atom | String.t() | number]
   @type view_type :: :gauge
+  @type value :: {atom, number}
+  @type reporter :: module
 
   @doc """
   Records a single measurement of a metric

--- a/lib/metrics.ex
+++ b/lib/metrics.ex
@@ -2,4 +2,20 @@ defmodule Metrics do
   @moduledoc """
   Application for gathering, aggregating and reporting metrics.
   """
+
+  alias Metrics.ViewStore
+
+  @type metric :: [atom | String.t() | number]
+  @type measurement :: number
+  @type view :: [atom | String.t() | number]
+
+  @doc """
+  Records a single measurement of a metric
+
+  Raises an error if given metric doesn't exist.
+  """
+  @spec record(metric, measurement) :: :ok
+  def record(metric, measurement) when is_list(metric) and is_number(measurement) do
+    ViewStore.dispatch(metric, measurement)
+  end
 end

--- a/lib/metrics.ex
+++ b/lib/metrics.ex
@@ -3,7 +3,7 @@ defmodule Metrics do
   Application for gathering, aggregating and reporting metrics.
   """
 
-  alias Metrics.{ViewStore, Gauge}
+  alias Metrics.{ViewStore, Gauge, Reporter}
 
   @type metric :: [atom | String.t() | number]
   @type measurement :: number
@@ -26,5 +26,13 @@ defmodule Metrics do
   @spec add_view(metric, view, view_type) :: :ok | {:error, :already_exists}
   def add_view(metric, view, :gauge) do
     Gauge.register(metric, view)
+  end
+
+  @doc """
+  Adds a new reporter susbcribed to all the metrics
+  """
+  @spec add_reporter(reporter) :: Supervisor.on_start_child()
+  def add_reporter(reporter) do
+    Reporter.start(reporter)
   end
 end

--- a/lib/metrics/application.ex
+++ b/lib/metrics/application.ex
@@ -7,6 +7,7 @@ defmodule Metrics.Application do
     children = [
       Metrics.FastTables,
       Metrics.ViewStore,
+      Metrics.Gauge,
       Metrics.ReporterStore,
       Metrics.ReporterSupervisor
     ]

--- a/lib/metrics/application.ex
+++ b/lib/metrics/application.ex
@@ -6,7 +6,8 @@ defmodule Metrics.Application do
   def start(_type, _args) do
     children = [
       Metrics.FastTables,
-      Metrics.ViewStore
+      Metrics.ViewStore,
+      Metrics.ReporterSupervisor
     ]
 
     opts = [strategy: :one_for_one, name: Metrics.Supervisor]

--- a/lib/metrics/application.ex
+++ b/lib/metrics/application.ex
@@ -4,7 +4,10 @@ defmodule Metrics.Application do
   use Application
 
   def start(_type, _args) do
-    children = []
+    children = [
+      Metrics.FastTables,
+      Metrics.ViewStore
+    ]
 
     opts = [strategy: :one_for_one, name: Metrics.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/metrics/application.ex
+++ b/lib/metrics/application.ex
@@ -8,6 +8,7 @@ defmodule Metrics.Application do
       Metrics.FastTables,
       Metrics.ViewStore,
       Metrics.Gauge,
+      Metrics.ProbeSupervisor,
       Metrics.ReporterStore,
       Metrics.ReporterSupervisor
     ]

--- a/lib/metrics/application.ex
+++ b/lib/metrics/application.ex
@@ -7,6 +7,7 @@ defmodule Metrics.Application do
     children = [
       Metrics.FastTables,
       Metrics.ViewStore,
+      Metrics.ReporterStore,
       Metrics.ReporterSupervisor
     ]
 

--- a/lib/metrics/fast_tables.ex
+++ b/lib/metrics/fast_tables.ex
@@ -1,6 +1,10 @@
 defmodule Metrics.FastTables do
   @moduledoc false
 
+  ## get/0 and get_all/0 could be parametrized, e.g. get(:views), get(:counters), etc. - -this way
+  ## we could try out and benchmark different implementations, e.g. separete tables for counters
+  ## and views, one global table etc.
+
   use GenServer
 
   @type t :: :ets.tab()

--- a/lib/metrics/fast_tables.ex
+++ b/lib/metrics/fast_tables.ex
@@ -1,0 +1,111 @@
+defmodule Metrics.FastTables do
+  @moduledoc false
+
+  use GenServer
+
+  @type t :: :ets.tab()
+
+  @spec get_all() :: [t(), ...]
+  def get_all() do
+    1..schedulers_online()
+    |> Enum.map(&table/1)
+  end
+
+  @spec get() :: t()
+  def get() do
+    table(current_scheduler_id())
+  end
+
+  @spec child_spec(any()) :: Supervisor.child_spec()
+  def child_spec(_) do
+    %{
+      id: __MODULE__,
+      start: {GenServer, :start_link, [__MODULE__, [], []]}
+    }
+  end
+
+  @impl true
+  def init(_) do
+    create_tables()
+    {:ok, []}
+  end
+
+  defp create_tables() do
+    heir = Process.whereis(Metrics.Supervisor)
+
+    for i <- 1..schedulers_online() do
+      table = table(i)
+      :ets.new(table, [:public, :bag, :named_table, {:heir, heir, []}, keypos: 1])
+    end
+  end
+
+  defp table(1), do: :metrics_table_1
+  defp table(2), do: :metrics_table_2
+  defp table(3), do: :metrics_table_3
+  defp table(4), do: :metrics_table_4
+  defp table(5), do: :metrics_table_5
+  defp table(6), do: :metrics_table_6
+  defp table(7), do: :metrics_table_7
+  defp table(8), do: :metrics_table_8
+  defp table(9), do: :metrics_table_9
+  defp table(10), do: :metrics_table_10
+  defp table(11), do: :metrics_table_11
+  defp table(12), do: :metrics_table_12
+  defp table(13), do: :metrics_table_13
+  defp table(14), do: :metrics_table_14
+  defp table(15), do: :metrics_table_15
+  defp table(16), do: :metrics_table_16
+  defp table(17), do: :metrics_table_17
+  defp table(18), do: :metrics_table_18
+  defp table(19), do: :metrics_table_19
+  defp table(20), do: :metrics_table_20
+  defp table(21), do: :metrics_table_21
+  defp table(22), do: :metrics_table_22
+  defp table(23), do: :metrics_table_23
+  defp table(24), do: :metrics_table_24
+  defp table(25), do: :metrics_table_25
+  defp table(26), do: :metrics_table_26
+  defp table(27), do: :metrics_table_27
+  defp table(28), do: :metrics_table_28
+  defp table(29), do: :metrics_table_29
+  defp table(30), do: :metrics_table_30
+  defp table(31), do: :metrics_table_31
+  defp table(32), do: :metrics_table_32
+  defp table(33), do: :metrics_table_33
+  defp table(34), do: :metrics_table_34
+  defp table(35), do: :metrics_table_35
+  defp table(36), do: :metrics_table_36
+  defp table(37), do: :metrics_table_37
+  defp table(38), do: :metrics_table_38
+  defp table(39), do: :metrics_table_39
+  defp table(40), do: :metrics_table_40
+  defp table(41), do: :metrics_table_41
+  defp table(42), do: :metrics_table_42
+  defp table(43), do: :metrics_table_43
+  defp table(44), do: :metrics_table_44
+  defp table(45), do: :metrics_table_45
+  defp table(46), do: :metrics_table_46
+  defp table(47), do: :metrics_table_47
+  defp table(48), do: :metrics_table_48
+  defp table(49), do: :metrics_table_49
+  defp table(50), do: :metrics_table_50
+  defp table(51), do: :metrics_table_51
+  defp table(52), do: :metrics_table_52
+  defp table(53), do: :metrics_table_53
+  defp table(54), do: :metrics_table_54
+  defp table(55), do: :metrics_table_55
+  defp table(56), do: :metrics_table_56
+  defp table(57), do: :metrics_table_57
+  defp table(58), do: :metrics_table_58
+  defp table(59), do: :metrics_table_59
+  defp table(60), do: :metrics_table_60
+  defp table(61), do: :metrics_table_61
+  defp table(62), do: :metrics_table_62
+  defp table(63), do: :metrics_table_63
+  defp table(64), do: :metrics_table_64
+  defp table(n) when is_integer(n) and n > 0, do: :"metrics_table_#{n}"
+
+  defp schedulers_online(), do: :erlang.system_info(:schedulers_online)
+
+  defp current_scheduler_id(), do: :erlang.system_info(:scheduler_id)
+end

--- a/lib/metrics/gauge.ex
+++ b/lib/metrics/gauge.ex
@@ -1,0 +1,39 @@
+defmodule Metrics.Gauge do
+  @moduledoc false
+
+  use GenServer
+
+  alias Metrics.{ViewStore, ReporterStore}
+
+  @spec child_spec(any) :: Supervisor.child_spec()
+  def child_spec(_) do
+    %{
+      id: __MODULE__,
+      start: {GenServer, :start_link, [__MODULE__, [], [name: __MODULE__]]}
+    }
+  end
+
+  @spec handle_measurement(Metrics.metric(), Metrics.view(), pid, Metrics.measurement()) :: :ok
+  def handle_measurement(metric, view, _, measurement) do
+    ## should we send keyword list of aggregated values or maybe a struct?
+    ## structs can be documented nicely but on the other hand reporters would need to know how
+    ## handle them
+    ReporterStore.dispatch(metric, view, [{:value, measurement}])
+  end
+
+  @spec register(Metrics.metric(), Metrics.view()) :: :ok | {:error, :already_exists}
+  def register(metric, view) do
+    GenServer.call(__MODULE__, {:register, metric, view})
+  end
+
+  @impl true
+  def init(_) do
+    {:ok, []}
+  end
+
+  @impl true
+  def handle_call({:register, metric, view}, _, state) do
+    reply = ViewStore.register(metric, view, __MODULE__)
+    {:reply, reply, state}
+  end
+end

--- a/lib/metrics/probe_supervisor.ex
+++ b/lib/metrics/probe_supervisor.ex
@@ -1,0 +1,21 @@
+defmodule Metrics.ProbeSupervisor do
+  @moduledoc false
+
+  use DynamicSupervisor
+
+  @spec child_spec(any) :: Supervisor.child_spec()
+  def child_spec(_) do
+    opts = [name: __MODULE__, strategy: :one_for_one]
+
+    %{
+      id: __MODULE__,
+      start: {DynamicSupervisor, :start_link, [opts]}
+    }
+  end
+
+  @spec start_child(Supervisor.child_spec() | module | {module, term}) ::
+          DynamicSupervisor.on_start_child()
+  def start_child(child_spec) do
+    DynamicSupervisor.start_child(__MODULE__, child_spec)
+  end
+end

--- a/lib/metrics/probes/memory.ex
+++ b/lib/metrics/probes/memory.ex
@@ -1,0 +1,121 @@
+defmodule Metrics.Probes.Memory do
+  @moduledoc """
+  Probe reporting memory usage periodically
+
+  It records the following metrics:
+  * `[:core, :memory, :allocated, :total]` - total amount of memory allocated
+  * `[:core, :memory, :allocated, :system]` - total amount of memory allocated minus the memory
+    allocated for processes
+  * `[:core, :memory, :allocated, :processes]` - total amount of memory allocated for processes
+  * `[:core, :memory, :allocated, :atoms]` - total amount of memory allocated for atoms
+  * `[:core, :memory, :allocated, :binaries]` - total amount of memory allocated for binaries
+  * `[:core, :memory, :allocated, :ets]` - total amount of memory allocated for ETS tables
+  * `[:core, :memory, :used, :atoms]` - total amount of memory used by atoms
+  * `[:core, :memory, :used, :processes]` - total amount of memory user by processes
+
+  Each metric's unit is bytes.
+
+  This probe also automatically adds a gauge view for each of these metrics with the same name
+  as the metric itself.
+  """
+
+  use GenServer
+
+  alias Metrics.ProbeSupervisor
+
+  @type interval :: pos_integer
+  @type option :: {:interval, interval}
+  @type options :: [option]
+
+  @default_interval 10_000
+
+  @doc """
+  Starts the memory probe
+
+  Allowed options:
+  * `:interval` - how often the memory metrics should be recorded. The unit is millisecond.
+  """
+  @spec start(options) :: Supervisor.on_start_child()
+  def start(opts \\ []) do
+    ProbeSupervisor.start_child(child_spec(opts))
+  end
+
+  @spec child_spec(options) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]}
+    }
+  end
+
+  @doc false
+  @spec start_link(options) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
+    interval = opts[:interval] || @default_interval
+    add_views()
+    set_timer(interval)
+    {:ok, %{interval: interval}}
+  end
+
+  @impl true
+  def handle_info(:record, state) do
+    record_metrics()
+    set_timer(state.interval)
+    {:noreply, state}
+  end
+
+  @spec set_timer(interval) :: :ok
+  defp set_timer(interval) do
+    Process.send_after(self(), :record, interval)
+  end
+
+  defp add_views() do
+    metrics = [
+      prefix_allocated(:total),
+      prefix_allocated(:system),
+      prefix_allocated(:processes),
+      prefix_allocated(:atoms),
+      prefix_allocated(:binaries),
+      prefix_allocated(:ets),
+      prefix_used(:atoms),
+      prefix_used(:processes)
+    ]
+
+    for metric <- metrics do
+      Metrics.add_view(metric, metric, :gauge)
+    end
+  end
+
+  defp record_metrics() do
+    memory_info = :erlang.memory()
+    Enum.each(memory_info, &record_metric/1)
+  end
+
+  @spec record_metric({:erlang.memory_type(), bytes :: non_neg_integer()}) :: :ok
+  defp record_metric({memory_type, size}) do
+    metric = metric_for_memory_type(memory_type)
+    if metric, do: Metrics.record(metric, size)
+  end
+
+  @spec metric_for_memory_type(:erlang.memory_type()) :: Metrics.metric()
+  defp metric_for_memory_type(:total), do: prefix_allocated(:total)
+  defp metric_for_memory_type(:system), do: prefix_allocated(:system)
+  defp metric_for_memory_type(:processes), do: prefix_allocated(:processes)
+  defp metric_for_memory_type(:atom), do: prefix_allocated(:atoms)
+  defp metric_for_memory_type(:binary), do: prefix_allocated(:binaries)
+  defp metric_for_memory_type(:ets), do: prefix_allocated(:ets)
+  defp metric_for_memory_type(:atom_used), do: prefix_used(:atoms)
+  defp metric_for_memory_type(:processes_used), do: prefix_used(:processes)
+  defp metric_for_memory_type(_), do: nil
+
+  @spec prefix_allocated(atom()) :: Metrics.metric()
+  defp prefix_allocated(suffix), do: [:core, :memory, :allocated, suffix]
+
+  @spec prefix_used(atom()) :: Metrics.metric()
+  defp prefix_used(suffix), do: [:core, :memory, :used, suffix]
+end

--- a/lib/metrics/reporter.ex
+++ b/lib/metrics/reporter.ex
@@ -1,64 +1,255 @@
 defmodule Metrics.Reporter do
   @moduledoc """
-  Behaviour for reporters forwarding values emitted by views to external systems
-
-  Currently there is no way to subscribe reporter only to specific metrics or views.
+  Behaviour for processes forwarding values emitted by views to external systems.
   """
 
   use GenServer
 
   alias Metrics.{ReporterSupervisor, ReporterStore}
 
-  @doc """
-  Called whenever any of the views emits its values
-
-  The last argument is the UTC timestamp when the values have been emitted.
-  """
-  @callback handle_emit(Metrics.metric(), Metrics.view(), [Metrics.value()], NaiveDateTime.t()) ::
-              any
+  @type state :: term()
 
   @doc """
-  Returns a child spec of the reporter
+  Called when the reporter process is initialized.
 
-  `args` is a list of arguments as you would pass to `start_link/2`.
+  It is used to set up initial reporter's state. `start_link/3` returns only after `init/1` returns.
+  See `c:GenServer.init/1` for the description of return values.
   """
-  @spec child_spec(list) :: Supervisor.child_spec()
-  def child_spec(args) when is_list(args) do
+  @callback init(arg :: term()) ::
+              {:ok, state()}
+              | {:ok, state(), timeout() | :hibernate}
+              | {:stop, reason :: any()}
+              | :ignore
+
+  @doc """
+  Called when any of the views emit the values.
+
+  `ts` argument is a UTC timestamp. For the description of return values see `handle_info/2`.
+  """
+  @callback handle_emit(
+              Metrics.metric(),
+              Metrics.view(),
+              [Metrics.value()],
+              Metrics.timestamp(),
+              state()
+            ) ::
+              {:noreply, new_state}
+              | {:noreply, new_state, timeout() | :hibernate}
+              | {:stop, reason :: any(), new_state}
+            when new_state: state()
+
+  @doc """
+  Called to handle all other messages received by the reporter process.
+
+  See `c:GenServer.terminate/2` for detailed description.
+  """
+  @callback handle_info(msg :: :timeout | term(), state()) ::
+              {:noreply, new_state}
+              | {:noreply, new_state, timeout() | :hibernate}
+              | {:stop, reason :: any(), new_state}
+            when new_state: state()
+
+  @doc """
+  Called when the reporter process is about to terminate.
+
+  See `c:GenServer.terminate/2` for detailed description.
+  """
+  @callback terminate(reason, state()) :: term()
+            when reason: :normal | :shutdown | {:shutdown, term()}
+
+  @doc """
+  Called in some cases o retrieve a formatted version of the reporter process status.
+
+  See `c:GenServer.format_status/2` for detailed description.
+  """
+  @callback format_status(reason, pdict_and_state :: list()) :: term()
+            when reason: :normal | :terminate
+
+  @doc """
+  Called to change the state of the reporter process when a different version of a module is loaded
+  (hot code swapping) and the state's structure should be changed.
+
+  See `c:GenServer.code_change/3` for detailed description.
+  """
+  @callback code_change(old_vsn, state(), extra :: term()) ::
+              {:ok, new_state :: state()} | {:error, reason :: term()} | {:down, term()}
+            when old_vsn: term()
+
+  @optional_callbacks [
+    handle_info: 2,
+    format_status: 2,
+    code_change: 3
+  ]
+
+  defmacro __using__(opts) do
+    quote location: :keep do
+      @behaviour Metrics.Reporter
+
+      @doc """
+      Returns a child specification to start this module under a supervisor
+
+      See documentation of `Supervisor` module for more information.
+      """
+      def child_spec(arg) do
+        default = %{
+          id: __MODULE__,
+          start: {Metrics.Reporter, :start_link, [__MODULE__, arg, []]}
+        }
+
+        Supervisor.child_spec(default, unquote(Macro.escape(opts)))
+      end
+
+      @impl true
+      def terminate(_reason, _state) do
+        :ok
+      end
+
+      defoverridable child_spec: 1, terminate: 2
+    end
+  end
+
+  @doc """
+  Starts a reporter process and links to the caller
+
+  `module` is a reporter module. `arg` is arbitrary term passed to `init/1` callback during
+  initialization. `opts` is a list of options as passed to `GenServer.start_link/3`.
+
+  This function can be used to start a reporter process as a part of supervision tree.
+  """
+  @spec start_link(module, arg :: term(), opts :: GenServer.options()) :: GenServer.on_start()
+  def start_link(mod, arg, opts \\ []) do
+    GenServer.start_link(__MODULE__, [mod, arg], opts)
+  end
+
+  @doc """
+  Starts a reporter process as a part of `Metrics` application supervision tree.
+
+  See `start_link/3` for description of arguments.
+  """
+  @spec start(module, arg :: term(), opts :: GenServer.options()) :: Supervisor.on_start_child()
+  def start(mod, arg, opts \\ []) do
+    ReporterSupervisor.start_child([mod, arg, opts])
+  end
+
+  @doc false
+  def child_spec(args) do
     %{
       id: __MODULE__,
       start: {__MODULE__, :start_link, args}
     }
   end
 
-  @doc """
-  Starts a given reporter and links to the calling process
-  """
-  @spec start_link(Metrics.reporter()) :: GenServer.on_start()
-  def start_link(reporter) do
-    GenServer.start_link(__MODULE__, [reporter], [])
-  end
-
   @doc false
-  @spec start(Metrics.reporter()) :: Supervisor.on_start_child()
-  def start(reporter) do
-    ReporterSupervisor.start_child([reporter])
-  end
-
-  @doc false
-  @spec notify(pid, Metris.metric(), Metrics.view(), [Metrics.value()], NaiveDateTime.t()) :: :ok
-  def notify(pid, metric, view, values, timestamp) do
-    GenServer.cast(pid, {:emitted, metric, view, values, timestamp})
+  @spec notify(pid, Metrics.metric(), Metrics.view(), [Metrics.value()], Metrics.timestamp()) ::
+          :ok
+  def notify(pid, metric, view, values, ts) do
+    GenServer.cast(pid, {:"$metrics_emitted", metric, view, values, ts})
   end
 
   @impl true
-  def init([reporter]) do
-    :ok = ReporterStore.register()
-    {:ok, %{reporter: reporter}}
+  def init([mod, arg]) do
+    Process.put(:"$initial_call", {mod, :init, 1})
+
+    case mod.init(arg) do
+      {:ok, int} ->
+        ReporterStore.register()
+        {:ok, make_initial_state(mod, int)}
+
+      {:ok, int, timeout_or_hibernate} ->
+        ReporterStore.register()
+        {:ok, make_initial_state(mod, int), timeout_or_hibernate}
+
+      {:stop, _reason} = stop ->
+        stop
+
+      :ignore ->
+        :ignore
+
+      other ->
+        {:stop, {:bad_return_value, other}}
+    end
   end
 
   @impl true
-  def handle_cast({:emitted, metric, view, values, timestamp}, state) do
-    state.reporter.handle_emit(metric, view, values, timestamp)
-    {:noreply, state}
+  def handle_cast({:"$metrics_emitted", metric, view, values, ts}, %{mod: mod, int: int} = state) do
+    result = mod.handle_emit(metric, view, values, ts, int)
+    handle_result(result, state)
   end
+
+  @impl true
+  def handle_info(msg, %{mod: mod, int: int} = state) do
+    try do
+      result = mod.handle_info(msg, int)
+      handle_result(result, state)
+    catch
+      :error, :undef ->
+        if function_exported?(mod, :handle_info, 2) do
+          :erlang.raise(:error, :undef, System.stacktrace())
+        else
+          {:registered_name, name} = Process.info(self(), :registered_name)
+          proc = if name == [], do: self(), else: name
+          pattern = 'Undefined handle_info/2 in ~p, process ~p received unexpected message ~p~n'
+          :error_logger.warning_msg(pattern, [mod, proc, msg])
+          {:noreply, state}
+        end
+    end
+  end
+
+  @impl true
+  def terminate(reason, %{mod: mod, int: int}) do
+    mod.terminate(reason, int)
+  end
+
+  @impl true
+  def format_status(reason, [pdict, %{mod: mod, int: int}]) do
+    try do
+      mod.format_status(reason, [pdict, int])
+    catch
+      :error, :undef ->
+        if function_exported?(mod, :format_status, 2) do
+          :erlang.raise(:error, :undef, System.stacktrace())
+        else
+          if reason == :normal do
+            [{:data, [{'State', int}]}]
+          else
+            int
+          end
+        end
+    end
+  end
+
+  @impl true
+  def code_change(old_vsn, new_vsn, %{mod: mod, int: int} = state) do
+    try do
+      mod.code_change(old_vsn, new_vsn, int)
+    catch
+      :error, :undef ->
+        if function_exported?(mod, :code_change, 3) do
+          :erlang.raise(:error, :undef, System.stacktrace())
+        else
+          {:ok, state}
+        end
+    else
+      {:ok, int} ->
+        {:ok, %{state | int: int}}
+
+      {:error, _reason} = ret ->
+        ret
+
+      {:down, _reason} = ret ->
+        ret
+    end
+  end
+
+  defp make_initial_state(mod, int) do
+    %{mod: mod, int: int}
+  end
+
+  defp handle_result({:noreply, int}, state), do: {:noreply, %{state | int: int}}
+
+  defp handle_result({:noreply, int, timeout_or_hibernate}, state),
+    do: {:noreply, %{state | int: int}, timeout_or_hibernate}
+
+  defp handle_result({:stop, reason, int}, state), do: {:stop, reason, %{state | int: int}}
+  defp handle_result(other, state), do: {:stop, {:bad_return_value, other}, state}
 end

--- a/lib/metrics/reporter.ex
+++ b/lib/metrics/reporter.ex
@@ -7,7 +7,7 @@ defmodule Metrics.Reporter do
 
   use GenServer
 
-  alias Metrics.ReporterSupervisor
+  alias Metrics.{ReporterSupervisor, ReporterStore}
 
   @doc """
   Called whenever any of the views emits its values
@@ -49,11 +49,12 @@ defmodule Metrics.Reporter do
   @doc false
   @spec notify(pid, Metris.metric(), Metrics.view(), [Metrics.value()], NaiveDateTime.t()) :: :ok
   def notify(pid, metric, view, values, timestamp) do
-    GenServer.cast(pid, {:emitted, metrics, view, values, timestamp})
+    GenServer.cast(pid, {:emitted, metric, view, values, timestamp})
   end
 
   @impl true
   def init([reporter]) do
+    :ok = ReporterStore.register()
     {:ok, %{reporter: reporter}}
   end
 

--- a/lib/metrics/reporter.ex
+++ b/lib/metrics/reporter.ex
@@ -1,0 +1,65 @@
+defmodule Metrics.Reporter do
+  @moduledoc """
+  Behaviour for reporters forwarding values emitted by views to external systems
+
+  Currently there is no way to subscribe reporter only to specific metrics or views.
+  """
+
+  use GenServer
+
+  alias Metrics.ReporterSupervisor
+
+  @doc """
+  Called whenever any of the views emits its values
+
+  The last argument is the UTC timestamp when the values have been emitted.
+  """
+  @callback handle_emit(Metrics.metric(), Metrics.view(), [Metrics.value()], NaiveDateTime.t()) ::
+              any
+
+  @doc """
+  Returns a child spec of the reporter
+
+  `args` is a list of arguments as you would pass to `start_link/2`.
+  """
+  @spec child_spec(list) :: Supervisor.child_spec()
+  def child_spec(args) when is_list(args) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, args}
+    }
+  end
+
+  @doc """
+  Starts a given reporter and links to the calling process
+  """
+  @spec start_link(Metrics.reporter()) :: GenServer.on_start()
+  def start_link(reporter) do
+    GenServer.start_link(__MODULE__, [reporter], [])
+  end
+
+  @doc """
+  Starts a given reporter under Metric's supervision tree
+  """
+  @spec start(Metrics.reporter()) :: Supervisor.on_start_child()
+  def start(reporter) do
+    ReporterSupervisor.start_child([reporter])
+  end
+
+  @doc false
+  @spec notify(pid, Metris.metric(), Metrics.view(), [Metrics.value()], NaiveDateTime.t()) :: :ok
+  def notify(pid, metric, view, values, timestamp) do
+    GenServer.cast(pid, {:emitted, metrics, view, values, timestamp})
+  end
+
+  @impl true
+  def init([reporter]) do
+    {:ok, %{reporter: reporter}}
+  end
+
+  @impl true
+  def handle_cast({:emitted, metric, view, values, timestamp}, state) do
+    state.reporter.handle_emit(metric, view, values, timestamp)
+    {:noreply, state}
+  end
+end

--- a/lib/metrics/reporter.ex
+++ b/lib/metrics/reporter.ex
@@ -38,9 +38,7 @@ defmodule Metrics.Reporter do
     GenServer.start_link(__MODULE__, [reporter], [])
   end
 
-  @doc """
-  Starts a given reporter under Metric's supervision tree
-  """
+  @doc false
   @spec start(Metrics.reporter()) :: Supervisor.on_start_child()
   def start(reporter) do
     ReporterSupervisor.start_child([reporter])

--- a/lib/metrics/reporter_store.ex
+++ b/lib/metrics/reporter_store.ex
@@ -1,0 +1,82 @@
+defmodule Metrics.ReporterStore do
+  @moduledoc false
+
+  use GenServer
+
+  alias Metrics.{FastTables, Reporter}
+
+  @typep fast_table_entry :: {:reporter, pid}
+
+  @spec child_spec(any) :: Supervisor.child_spec()
+  def child_spec(_) do
+    %{
+      id: __MODULE__,
+      start: {GenServer, :start_link, [__MODULE__, [], [name: __MODULE__]]},
+      type: :worker
+    }
+  end
+
+  @spec register() :: :ok | {:error, :already_registered}
+  def register() do
+    GenServer.call(__MODULE__, {:register, self()})
+  end
+
+  @spec dispatch(Metrics.metric(), Metrics.view(), [Metrics.value()]) :: :ok
+  def dispatch(metric, view, values) do
+    timestamp = NaiveDateTime.utc_now()
+
+    for {:reporter, pid} <- get_reporters() do
+      Reporter.notify(pid, metric, view, values, timestamp)
+    end
+  end
+
+  @spec get_reporters() :: [fast_table_entry]
+  defp get_reporters() do
+    :ets.lookup(FastTables.get(), :reporter)
+  end
+
+  @impl true
+  def init(_) do
+    {:ok, %{monitors: %{}, reporters: MapSet.new()}}
+  end
+
+  @impl true
+  def handle_call({:register, pid}, _, state) do
+    if MapSet.member?(state.reporters, pid) do
+      {:reply, {:error, :already_registered}, state}
+    else
+      reporters = MapSet.put(state.reporters, pid)
+      ref = Process.monitor(pid)
+      monitors = Map.put(state.monitors, pid, ref)
+      add_fast_tables_entry(pid)
+      new_state = %{state | reporters: reporters, monitors: monitors}
+      {:reply, :ok, new_state}
+    end
+  end
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, pid, _}, state) do
+    ^ref = Map.get(state.monitors, pid)
+    remove_fast_tables_entry(pid)
+    monitors = Map.delete(state.monitors, pid)
+    reporters = MapSet.delete(state.reporters, pid)
+    new_state = %{state | reporters: reporters, monitors: monitors}
+    {:noreply, new_state}
+  end
+
+  @spec add_fast_tables_entry(pid) :: any
+  defp add_fast_tables_entry(pid) do
+    entry = {:reporter, pid}
+
+    for table <- FastTables.get_all() do
+      :ets.insert(table, entry)
+    end
+  end
+
+  @spec remove_fast_tables_entry(pid) :: any
+  defp remove_fast_tables_entry(pid) do
+    for table <- FastTables.get_all() do
+      :ets.delete_object(table, {:reporter, pid})
+    end
+  end
+end

--- a/lib/metrics/reporter_supervisor.ex
+++ b/lib/metrics/reporter_supervisor.ex
@@ -1,0 +1,29 @@
+defmodule Metrics.ReporterSupervisor do
+  @moduledoc false
+
+  use Supervisor
+
+  alias Metrics.Reporter
+
+  @spec child_spec(any) :: Supervisor.child_spec()
+  def child_spec(_) do
+    %{
+      id: __MODULE__,
+      start: {Supervisor, :start_link, [__MODULE__, [], [name: __MODULE__]]}
+    }
+  end
+
+  @spec start_child(list) :: Supervisor.on_start_child()
+  def start_child(args) when is_list(args) do
+    Supervisor.start_child(__MODULE__, args)
+  end
+
+  @impl true
+  def init(_) do
+    children = [
+      {Reporter, []}
+    ]
+
+    Supervisor.init(children, strategy: :simple_one_for_one)
+  end
+end

--- a/lib/metrics/reporters/console.ex
+++ b/lib/metrics/reporters/console.ex
@@ -1,0 +1,24 @@
+defmodule Metrics.Reporters.Console do
+  @moduledoc """
+  Reporter printing emitted values to the console
+  """
+
+  @behaviour Metrics.Reporter
+
+  def handle_emit(_metric, view, values, timestamp) do
+    formatted_ts = NaiveDateTime.to_iso8601(timestamp)
+
+    formatted_view =
+      view
+      |> Enum.map(&to_string/1)
+      |> Enum.intersperse(?.)
+
+    formatted_vals =
+      values
+      |> Enum.map(fn {name, val} -> [to_string(name), ?=, to_string(val)] end)
+      |> Enum.intersperse(?\s)
+
+    line = [?[, formatted_ts, ?], ?\s, formatted_view, ?:, ?\s, formatted_vals]
+    IO.puts(line)
+  end
+end

--- a/lib/metrics/reporters/console.ex
+++ b/lib/metrics/reporters/console.ex
@@ -5,8 +5,9 @@ defmodule Metrics.Reporters.Console do
 
   @behaviour Metrics.Reporter
 
-  def handle_emit(_metric, view, values, timestamp) do
-    formatted_ts = NaiveDateTime.to_iso8601(timestamp)
+  def handle_emit(_metric, view, values, ts) do
+    formatted_date = ts |> NaiveDateTime.to_date() |> Date.to_iso8601()
+    formatted_time = ts |> NaiveDateTime.to_time() |> Time.to_iso8601()
 
     formatted_view =
       view
@@ -18,7 +19,21 @@ defmodule Metrics.Reporters.Console do
       |> Enum.map(fn {name, val} -> [to_string(name), ?=, to_string(val)] end)
       |> Enum.intersperse(?\s)
 
-    line = [?[, formatted_ts, ?], ?\s, formatted_view, ?:, ?\s, formatted_vals]
+    line = [
+      "report ",
+      ?[,
+      formatted_date,
+      ?],
+      ?[,
+      formatted_time,
+      ?],
+      ?\s,
+      formatted_view,
+      ?:,
+      ?\s,
+      formatted_vals
+    ]
+
     IO.puts(line)
   end
 end

--- a/lib/metrics/reporters/console.ex
+++ b/lib/metrics/reporters/console.ex
@@ -3,9 +3,15 @@ defmodule Metrics.Reporters.Console do
   Reporter printing emitted values to the console
   """
 
-  @behaviour Metrics.Reporter
+  use Metrics.Reporter
 
-  def handle_emit(_metric, view, values, ts) do
+  @impl true
+  def init(_arg) do
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_emit(_metric, view, values, ts, state) do
     formatted_date = ts |> NaiveDateTime.to_date() |> Date.to_iso8601()
     formatted_time = ts |> NaiveDateTime.to_time() |> Time.to_iso8601()
 
@@ -35,5 +41,6 @@ defmodule Metrics.Reporters.Console do
     ]
 
     IO.puts(line)
+    {:noreply, state}
   end
 end

--- a/lib/metrics/view.ex
+++ b/lib/metrics/view.ex
@@ -1,0 +1,8 @@
+defmodule Metrics.View do
+  @moduledoc """
+  A view behaviour
+
+  Users willing to extend `Metrics` functionality with new metric views need to create a module
+  implmenenting this behaviour's callbacks.
+  """
+end

--- a/lib/metrics/view_store.ex
+++ b/lib/metrics/view_store.ex
@@ -1,0 +1,105 @@
+defmodule Metrics.ViewStore do
+  @moduledoc false
+  ## GenServer managing views. All additions and removals of views go through this process to
+  ## guarantee atomicity of these operations through all fast tables.
+  ##
+  ## Miscellanous info like view description could be stored in a single table, since access to it
+  ## doesn't lie on the critical path.
+
+  use GenServer
+
+  alias Metrics.FastTables
+
+  @typep fast_table_entry :: {{:view, Metrics.metric()}, Metrics.view(), module(), pid()}
+  @typep monitors :: %{pid => {reference, [Metrics.view()]}}
+
+  @spec child_spec(any) :: Supervisor.child_spec()
+  def child_spec(_) do
+    %{
+      id: __MODULE__,
+      start: {GenServer, :start_link, [__MODULE__, [], [name: __MODULE__]]},
+      type: :worker
+    }
+  end
+
+  @spec register(Metrics.metric(), Metrics.view(), module()) :: :ok | {:error, :already_exists}
+  def register(metric, view, view_module) do
+    GenServer.call(__MODULE__, {:register, metric, view, view_module, self()})
+  end
+
+  @spec dispatch(Metrics.metric(), Metrics.measurement()) :: :ok
+  def dispatch(metric, measurement) do
+    for {{:view, ^metric}, view, view_module, view_pid} <- get_views(metric) do
+      view_module.handle_measurement(metric, view, view_pid, measurement)
+    end
+
+    :ok
+  end
+
+  @spec get_views(Metrics.metric()) :: [fast_table_entry()]
+  defp get_views(metric) do
+    :ets.lookup(FastTables.get(), {:view, metric})
+  end
+
+  @impl true
+  def init(_) do
+    {:ok, %{monitors: %{}, views: MapSet.new()}}
+  end
+
+  @impl true
+  def handle_call({:register, metric, view, view_module, view_pid}, _, state) do
+    if MapSet.member?(state.views, view) do
+      {:reply, {:error, :already_exists}, state}
+    else
+      views = MapSet.put(state.views, view)
+      monitors = maybe_monitor(state.monitors, view_pid, view)
+      add_fast_tables_entry(metric, view, view_module, view_pid)
+      new_state = %{state | views: views, monitors: monitors}
+      {:reply, :ok, new_state}
+    end
+  end
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, pid, _}, state) do
+    {^ref, views} = Map.get(state.monitors, pid)
+    remove_fast_tables_entries(views)
+    monitors = Map.delete(state.monitors, pid)
+    views = Enum.reduce(views, state.views, fn view, views -> MapSet.delete(views, view) end)
+    new_state = %{state | views: views, monitors: monitors}
+    {:noreply, new_state}
+  end
+
+  @spec maybe_monitor(monitors, pid, Metrics.view()) :: monitors
+  defp maybe_monitor(monitors, pid, view) do
+    case Map.fetch(monitors, pid) do
+      {:ok, {ref, views}} ->
+        Map.put(monitors, pid, {ref, [view | views]})
+
+      :error ->
+        ref = Process.monitor(pid)
+        Map.put(monitors, pid, {ref, [view]})
+    end
+  end
+
+  @spec add_fast_tables_entry(Metrics.metric(), Metrics.view(), module(), pid) :: any
+  defp add_fast_tables_entry(metric, view, view_module, pid) do
+    entry = {{:view, metric}, view, view_module, pid}
+
+    for table <- FastTables.get_all() do
+      :ets.insert(table, entry)
+    end
+  end
+
+  @spec remove_fast_tables_entries([Metrics.view()]) :: any
+  defp remove_fast_tables_entries(views), do: Enum.each(views, &remove_fast_tables_entry/1)
+
+  @spec remove_fast_tables_entry(Metrics.view()) :: any
+  defp remove_fast_tables_entry(view) do
+    pattern = {{:view, :_}, view, :_, :_}
+
+    for table <- FastTables.get_all() do
+      [entry] = :ets.match_object(table, pattern)
+      :ets.delete_object(table, entry)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule Metrics.MixProject do
       version: "0.1.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps()
     ]
   end
@@ -17,6 +18,9 @@ defmodule Metrics.MixProject do
       mod: {Metrics.Application, []}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib/", "test/support/"]
+  defp elixirc_paths(_), do: ["lib/"]
 
   defp deps do
     []

--- a/test/metrics_test.exs
+++ b/test/metrics_test.exs
@@ -1,3 +1,20 @@
 defmodule MetricsTest do
   use ExUnit.Case
+
+  @metric [:metrics, :test, :metric]
+  @view [:metrics, :test, :metric, :gauge]
+
+  setup do
+    start_supervised!({Metrics.Test.EchoReporter, owner: self()})
+    :ok
+  end
+
+  test "recorded measurements are forwarded by gauge view to reporter" do
+    Metrics.add_view(@metric, @view, :gauge)
+
+    measurement = 16.50
+    Metrics.record(@metric, measurement)
+
+    assert_receive {:report, @metric, @view, [{:value, ^measurement}], _ts}
+  end
 end

--- a/test/support/test_reporter.ex
+++ b/test/support/test_reporter.ex
@@ -1,0 +1,19 @@
+defmodule Metrics.Test.EchoReporter do
+  @moduledoc """
+  Simple reporter sending received values to configured owner process
+  """
+
+  use Metrics.Reporter
+
+  @impl true
+  def init(opts) do
+    owner = Keyword.fetch!(opts, :owner)
+    {:ok, %{owner: owner}}
+  end
+
+  @impl true
+  def handle_emit(metric, view, values, ts, state) do
+    send(state.owner, {:report, metric, view, values, ts})
+    {:noreply, state}
+  end
+end


### PR DESCRIPTION
This PR introduces enough bits and pieces to run a full monitoring scenario, i.e. create a metric and its view, attach a reporter and send metric somewhere (console in this case).

The simplest demo would be:

```
iex -S mix
iex> Metrics.add_reporter(Metrics.Reporters.Console)
iex> Metrics.Probes.Memory.start
```

You'll see some measurements of memory usage reported in the console every ten seconds. Now on to the hard stuff..

Right below you'll find a glossary section. Later on there is a "How it works" describing some architectural choices. Note that this is a proof of concept, everything is a subject to change.

## Glossary

Drawing from the tradition of all Erlang libraries, we need to have at least 3 pages long glossary at top of the README. This is a humble attempt to achieve this 😄 

### Metric

Metric is a collection of measurements. That's it. Is has a name, a description, maybe a unit, but it's an abstract collection of values. 

Measurement is always a number. How the collection of measurements (i.e. metric) is represented depends on *views* subscribed to it.

We should allow easy exploration of metrics, especially given that they will have descriptions.

### View

View receives measurements of a single metric and aggregates them. Aggregation may have many forms, e.g. a view might emit only the last recorded value (gauge), the rate of measurements recorded per unit of time, or quantiles, mean, min and max (the so called "histogram", although I don't really like this name). Each view performs only a single type of aggregation, but the result of aggregation might consist of many values (like in the example of histogram).

View chooses when to emit aggregated values which are **pushed** to *reporters*. This is different than most metric systems, usually values are pulled from aggregators. However we figured that in most cases it doesn't make sense to have independent metric interval (if you have a good example when that's needed, please tell!). Obviously this comes with the possibility of flooding reporters with  values - but we'll know when we measure/profile/benchmark. Recordings of metrics are the source of load in the system anyway, not the views emitting values.

View may be subscribed only to a single metric, but a single metric may have many views subscribed to it. Views also have a name, description, and maybe a unit.

Similarily to metrics, views also should be easily explorable. We should also define a behaviour, so that it's easy to create own views.

I'm not sure if views should be reconfigurable at runtime. Does it makes sense to change the size of the sliding window over which percentiles are calculated?

### Reporters

Reporters are quite self-explanatory, they report aggregated values to external systems. Reporters should have some kind of indentifier, so that we could reconfigure them in runtime (similar to Logger backends). Reporters should be able to subscribe to all metrics, selected metrics, or selected views.

There should be (and already is! a simple one, though) a behaviour for reporters. 

### Probes

Probe is a thing which periodically makes and records a measurement. In this PR there is a memory usage probe. There is nothing fancy going on with them, I'm not sure if there should be some kind of behaviour for them or just a name.

# How it works

Given that we defined metric as an abstract concept, the only thing we need to know about them is that if anyone's interested in their measurements (there is currently no place in code where the metric is registered etc.). Because of that, I tried to keep it simple and in this version you can only define views. 

Created views are kept in an ETS table. I've used the solution implemented in exometer, where there is an ETS table per scheduler, and the process always uses the table assigned to the scheduler it's currently running on (`Metrics.FastTables`). This means that we need to put a view registration info in each of those tables. To preserve "atomicity" view registration always goes through one process. This also allows us to reject registration of views with duplicate names. This process (`Metrics.ViewStore`) also monitors the process which performs a registration and removes views defined by it when it goes down. Currently we have only gauge views, and there is a single, dedicated process which does registration. I imagine that in the future when we have stateful views, like "histogram" or "rate" they would register themselves in the store.

When someone records a measurement, we look up views subscribed to it (in a table assigned to scheduler the process is running on) and call a `handle_measurement` callback (there isn't really a behaviour for that yet, because I imagine that we stateful views we would need more callbacks anyway). In case of gauges, recorded measurements are immediately pushed to reporters subscribed to that metric (more on reporter subcriptions below). We chose the route with pushing values to reporters, because it simply makes sense that the aggregator chooses when to emit a value. In case of gauges it doesn't make sense to report values every minute - why would I use gauge if I lose most of the values this way? The same goes for views which calculate some stats over the sliding window - it doesn't make much sense to report every 15 seconds, if I aggregate values from the last minute - it even looks confusing on the plotted chart. Again, if anyone know a good use case for having separate report interval, I'd be happy to hear it 🙂 
The next view I wanted to implemented was a counter. Basically we would have a per-counter entry in all ETS tables, and have a dedicated process which periodically sums the counters, resets them and pushes to reporters. This process would also perform a registration in a `ViewStore`.

The other thing about views - I think that we could document it somewhere that it rarely makes sense to attach multiple views of different types to the same metric. The only example I was thinking of was when measurement is a request latency and we can have one view calculating quantiles, and the other view counting the rate of requests. But I'd still say that these should be some separate metrics. Multiple views of the same metric might be useful, for example, when we want to have a counter of events over last minute, but also since the start of the system. That would be a single metric, with two views of the same type, but with different configurations.

Reporters are also registered in these "fast" ETS tables. However, currently there is no way to control which views or metrics they are subscribed to.